### PR TITLE
containerize WireVault for production (Docker + Caddy + Compose)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+# VCS / local
+.git
+.gitignore
+
+# Dependencies / builds
+node_modules
+.next
+dist
+out
+
+# Local env / data
+.env
+*.db
+public/uploads

--- a/.env.compose.example
+++ b/.env.compose.example
@@ -1,0 +1,10 @@
+# Used by docker-compose (NOT the app's .env)
+SESSION_HMAC_SECRET=please-change-to-a-long-random-string
+
+# Caddy config
+DOMAIN=wirevault.up2charge.be
+EMAIL=you@up2charge.be
+
+# Optional admin seed (only used if you run the seed script)
+ADMIN_SEED_EMAIL=admin@up2charge.be
+ADMIN_SEED_PASSWORD=ChangeMe123!

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,14 @@
+{$DOMAIN} {
+    encode zstd gzip
+
+    @uploads path /uploads/*
+    handle @uploads {
+        root * /data/uploads
+        file_server
+        header {
+            X-Content-Type-Type nosniff
+        }
+    }
+
+    reverse_proxy app:3000
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+# ---- base
+FROM node:20-alpine AS base
+WORKDIR /app
+ENV NEXT_TELEMETRY_DISABLED=1
+
+# ---- deps
+FROM base AS deps
+COPY package.json package-lock.json* ./
+RUN npm ci
+
+# ---- build
+FROM deps AS build
+COPY prisma ./prisma
+RUN npx prisma generate
+COPY . .
+RUN npm run build
+
+# ---- runtime
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+
+# non-root user
+RUN addgroup -g 1001 nodejs && adduser -S -u 1001 nextjs
+
+# copy artifacts
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/.next ./.next
+COPY --from=build /app/package.json ./package.json
+COPY --from=build /app/next.config.mjs ./next.config.mjs
+COPY --from=build /app/public ./public
+COPY --from=build /app/prisma ./prisma
+
+# entrypoint runs migrations before start
+COPY docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+USER 1001
+EXPOSE 3000
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["npm","start"]

--- a/README-Docker.md
+++ b/README-Docker.md
@@ -1,0 +1,66 @@
+# WireVault – Docker Deployment Bundle
+
+This folder contains everything to run WireVault in containers with automatic HTTPS via Caddy.
+
+## Files
+- `Dockerfile` – Multi-stage build for Next.js + Prisma.
+- `docker-compose.yml` – Default stack using a named volume `wirevault-data`.
+- `docker-compose.lxc.yml` – Alternate stack for Proxmox LXC with a host bind mount at `/data`.
+- `Caddyfile` – Serves `/uploads/*` directly from the data volume and reverse proxies the app.
+- `docker/entrypoint.sh` – Runs `prisma migrate deploy` before starting the app.
+- `prisma/seed.cjs` – Optional production seed script (admin + DEMO01).
+- `.dockerignore`
+- `.env.compose.example` – Example env file for Compose.
+
+## Quick start (generic server)
+```bash
+# 1) Copy these files into your project root
+# 2) Create a .env (compose) from the example
+cp .env.compose.example .env
+# Edit DOMAIN, EMAIL, and set a strong SESSION_HMAC_SECRET
+
+# 3) Build & run
+docker compose up -d --build
+
+# 4) (Optional) seed demo/admin
+docker compose run --rm app node prisma/seed.cjs
+```
+
+Your site will be at: `https://$DOMAIN`
+
+- Uploads: `/uploads/<shortId>/<file>` (served by Caddy from the shared data volume)
+- SQLite DB: `/data/prod.db` (inside the volume)
+
+## Proxmox LXC variant
+If you created an LXC with a **mount point** from the host to `/data` in the container, use:
+
+```bash
+docker compose -f docker-compose.lxc.yml up -d --build
+```
+
+This binds the app & caddy to `/data` so your DB and uploads live on the Proxmox host storage.
+
+## Updates
+```bash
+git pull
+docker compose up -d --build app
+```
+
+## Rollback
+```bash
+git checkout v1.0.0   # or any known-good tag/commit
+docker compose up -d --build app
+```
+
+## Backups (DB + uploads)
+```bash
+docker run --rm -v wirevault-data:/data -v "$PWD":/backup alpine \\
+  sh -c 'tar -czf /backup/wirevault-backup-$(date +%F-%H%M).tgz -C / data'
+```
+
+> For the LXC variant replace the volume with `-v /data:/data`.
+
+## Notes
+- The app expects `UPLOAD_ROOT=/data/uploads`, so `/uploads/*` maps to files on disk.
+- Entry point applies DB migrations automatically (`prisma migrate deploy`).
+- Keep Prisma migrations committed in your repo.

--- a/docker-compose.lxc.yml
+++ b/docker-compose.lxc.yml
@@ -1,0 +1,42 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: wirevault:${APP_VERSION:-local}
+    environment:
+      NODE_ENV: production
+      DATABASE_URL: "file:/data/prod.db"
+      UPLOAD_ROOT: "/data/uploads"
+      SESSION_HMAC_SECRET: "${SESSION_HMAC_SECRET}"
+      PIN_HASH_SALT_ROUNDS: "10"
+      SESSION_TTL_MINUTES: "20"
+      ADMIN_SEED_EMAIL: "${ADMIN_SEED_EMAIL:-admin@up2charge.be}"
+      ADMIN_SEED_PASSWORD: "${ADMIN_SEED_PASSWORD:-ChangeMe123!}"
+    volumes:
+      - /data:/data
+    restart: unless-stopped
+    networks: [web]
+
+  caddy:
+    image: caddy:2
+    restart: unless-stopped
+    ports: ["80:80","443:443"]
+    environment:
+      ACME_AGREE: "true"
+      DOMAIN: "${DOMAIN}"
+      EMAIL: "${EMAIL}"
+    volumes:
+      - /data:/data
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data/caddy
+      - caddy-config:/config
+    networks: [web]
+
+volumes:
+  caddy-data:
+  caddy-config:
+
+networks:
+  web:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: wirevault:${APP_VERSION:-local}
+    environment:
+      NODE_ENV: production
+      DATABASE_URL: "file:/data/prod.db"
+      UPLOAD_ROOT: "/data/uploads"
+      SESSION_HMAC_SECRET: "${SESSION_HMAC_SECRET}"
+      PIN_HASH_SALT_ROUNDS: "10"
+      SESSION_TTL_MINUTES: "20"
+      ADMIN_SEED_EMAIL: "${ADMIN_SEED_EMAIL:-admin@up2charge.be}"
+      ADMIN_SEED_PASSWORD: "${ADMIN_SEED_PASSWORD:-ChangeMe123!}"
+    volumes:
+      - wirevault-data:/data
+    restart: unless-stopped
+    networks: [web]
+
+  caddy:
+    image: caddy:2
+    restart: unless-stopped
+    ports: ["80:80","443:443"]
+    environment:
+      ACME_AGREE: "true"
+      DOMAIN: "${DOMAIN}"
+      EMAIL: "${EMAIL}"
+    volumes:
+      - wirevault-data:/data
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data/caddy
+      - caddy-config:/config
+    networks: [web]
+
+volumes:
+  wirevault-data:
+  caddy-data:
+  caddy-config:
+
+networks:
+  web:
+    driver: bridge


### PR DESCRIPTION
Adds a production-ready container setup:

- Dockerfile (multi-stage, Prisma generate at build)
- docker-compose.yml (named volume for DB + uploads)
- docker-compose.lxc.yml (Proxmox LXC bind-mount to /data)
- Caddyfile (auto HTTPS + serves /uploads/*)
- docker/entrypoint.sh (runs `prisma migrate deploy` before start)
- prisma/seed.cjs (optional production seeder)
- .dockerignore
- .env.compose.example (Compose env template)
- README-Docker.md (step-by-step deploy guide)

Next steps:
1) Create `.env` (copy from `.env.compose.example`) and set:
   - SESSION_HMAC_SECRET=<long random>
   - DOMAIN=wirevault.up2charge.be
   - EMAIL=you@up2charge.be
2) On server/LXC:
   - `docker compose up -d --build`
   - (Optional seed): `docker compose run --rm app node prisma/seed.cjs`